### PR TITLE
Suppress push notifications when user is actively viewing the room

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,8 @@ PATCH   /rooms/{id}/messages/{msgID}       — edit own message → 204 + SSE ed
 DELETE  /rooms/{id}/messages/{msgID}       — delete own message → 204 + SSE delete event
 POST /rooms/{id}/messages/{msgID}/reactions — toggle emoji reaction → 204 + SSE reaction event
 GET  /rooms/{id}/members                   — room member list for @mention autocomplete
+POST /rooms/{id}/active                    — record user as actively viewing room (updates last_active + viewing key)
+POST /rooms/{id}/inactive                  — clear viewing key immediately (called via sendBeacon on hide)
 GET  /rooms/{id}/upload-url?hash=&content_type=&content_length=  — presign S3 PUT (optional)
 
 GET  /push/vapid-public-key                — VAPID public key (unauthenticated)
@@ -142,6 +144,8 @@ messages:{msg-id}                       Hash    id, room_id, user_id, text, atta
 reactions:{msg-id}                      Hash    emoji → count; TTL 30 days
 reactions:{msg-id}:users                Hash    "{emoji}\x00{userID}" → "1"; TTL 30 days
 unfurls:{sha256-of-url}                 String  JSON Unfurl or "null"; TTL 24h (success) / 15 min (failure)
+users:{uuid}:rooms:{roomId}:last_active String  unix ms timestamp; TTL 30 days (reset on each write)
+users:{uuid}:rooms:{roomId}:viewing    String  "1"; TTL 90 s; reset by heartbeat every 60 s; cleared immediately by leave beacon
 users:{uuid}:password                   String  bcrypt hash (cost 12); no TTL; only set for password-auth accounts
 email_index:{email}                     String  canonical uuid; no TTL; written by createuser CLI
 ```

--- a/docs/read-cursor.md
+++ b/docs/read-cursor.md
@@ -1,0 +1,79 @@
+# Read Cursor & Unread Tracking
+
+## Concept
+
+Count a message as "seen" when a browser tab/PWA that is **visible** (not just focused) has drawn the message in the viewport.
+
+### Use cases
+
+1. **Unread count in titlebar** — show `(3) msg` or a dot indicator for unread messages
+2. **Push suppression** — if the user is actively viewing the room on one device, don't send a push notification to their other devices
+
+---
+
+## Design notes
+
+### "Focus" vs. "Visibility"
+
+Use `document.visibilityState === 'visible'` (Page Visibility API), not `document.hasFocus()`.
+
+- A tab can be **visible** (on screen, user is looking at it) without having keyboard focus (e.g. user is reading but typing in a terminal elsewhere).
+- `hasFocus()` would miss this common case.
+
+### "Drawn" vs. "In viewport"
+
+A message being rendered in the DOM does not mean the user has seen it — they may have scrolled past it. Use the **Intersection Observer API** to mark a message as seen only when it actually enters the viewport while the tab is visible.
+
+### Persistence
+
+The read cursor must survive page reloads and device switches — it must be stored in Redis.
+
+Proposed key: `users:{uuid}:rooms:{roomId}:last_read` = unix ms timestamp of last seen message.
+
+### Multi-tab sync
+
+Two tabs on the same browser can get out of sync. **BroadcastChannel API** can propagate cursor updates to sibling tabs cheaply. Cross-device sync goes through Redis.
+
+---
+
+## Unified mechanism: `last_active` per room
+
+Both use cases are served by a single `last_active` timestamp, scoped per user per room.
+
+**Redis key:** `users:{uuid}:rooms:{roomId}:last_active` = unix ms timestamp
+
+### Push suppression
+
+Skip push if `last_active` for the target room is within the last N minutes (e.g. 5 min). More accurate than checking SSE connection presence, which can stay open for hours after the user has walked away.
+
+### Unread count / read cursor
+
+Messages with `created_at > last_active` = unread. This is the read cursor.
+
+Precision trade-off: if the user is in the room but scrolled up reading history while new messages arrive below the fold, those messages are implicitly marked read. Acceptable for a chat hint — this is not a legal audit trail.
+
+### When to update `last_active`
+
+Client signals to server via a lightweight POST/PUT:
+- Tab becomes visible (`visibilitychange` → visible)
+- User sends a message (already implies presence)
+- Optionally: periodic heartbeat while tab is visible (keep TTL alive)
+
+### Why not SSE connection presence alone
+
+SSE connections stay open indefinitely — no server-side idle timeout, no keepalive heartbeat. A tab left open overnight still has a live SSE connection. `last_active` with a recency threshold is a much more accurate signal.
+
+---
+
+## Implementation status
+
+### Push suppression — **implemented**
+
+- **Redis key:** `users:{uuid}:rooms:{roomId}:last_active` (String, unix ms; TTL 30 days)
+- **Suppression threshold:** 2 minutes — push skipped if `now - last_active < 2 min`
+- **Heartbeat interval:** 60 seconds while tab is visible
+- **Server endpoint:** `POST /rooms/{id}/active` → 204 (auth required)
+- **Client signals:** page load (if visible), `visibilitychange` → visible, every 60 s
+- **Message send:** also updates `last_active` for the sender (fire-and-forget)
+
+### Unread count / read cursor — **not yet implemented**

--- a/internal/handler/messages.go
+++ b/internal/handler/messages.go
@@ -107,10 +107,12 @@ func (h *MessagesHandler) HandlePost(w http.ResponseWriter, r *http.Request) {
 		_ = h.Redis.Publish(r.Context(), roomID, "msg:"+html)
 	}
 
-	// Track room membership (scored by time so we know who's recently active).
+	// Track room membership and last-active timestamp.
 	go func() {
 		ctx2 := context.Background()
 		_ = h.Redis.TouchRoomMember(ctx2, roomID, user.ID)
+		_ = h.Redis.SetRoomLastActive(ctx2, user.ID, roomID)
+		_ = h.Redis.SetRoomViewing(ctx2, user.ID, roomID)
 	}()
 
 	// Async unfurl.
@@ -179,6 +181,11 @@ func (h *MessagesHandler) sendPushNotifications(msg model.Message, mentionedName
 		}
 		if muted {
 			continue
+		}
+
+		viewing, err := h.Redis.IsRoomViewing(ctx, memberID, msg.RoomID)
+		if err == nil && viewing {
+			continue // user is actively viewing this room
 		}
 
 		subs, err := h.Redis.GetAllPushSubscriptions(ctx, memberID)

--- a/internal/handler/messages_test.go
+++ b/internal/handler/messages_test.go
@@ -448,6 +448,68 @@ func TestHandlePost_PushExpiredSubscription(t *testing.T) {
 	t.Fatal("expired subscription was not cleaned up within 2s")
 }
 
+func TestHandlePost_PushSkipsActiveRecipient(t *testing.T) {
+	received := make(chan struct{}, 10)
+	fakePush := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		received <- struct{}{}
+	}))
+	defer fakePush.Close()
+
+	sender := buildPushSender(t)
+	ts := testutil.NewTestServerWithPush(t, sender)
+	ts.SeedRoom(t, model.Room{ID: testRoom, Name: "Test Room"})
+	require.NoError(t, ts.Redis.CreateUser(context.Background(), bob))
+	require.NoError(t, ts.Redis.TouchRoomMember(context.Background(), testRoom, alice.ID))
+	require.NoError(t, ts.Redis.TouchRoomMember(context.Background(), testRoom, bob.ID))
+
+	subJSON := bobSubscriptionJSON(t, fakePush.URL)
+	require.NoError(t, ts.Redis.SavePushSubscription(context.Background(), bob.ID, fakePush.URL, subJSON))
+
+	// Mark bob as actively viewing the room.
+	require.NoError(t, ts.Redis.SetRoomViewing(context.Background(), bob.ID, testRoom))
+
+	resp := postMsg(t, ts, alice, "hello bob")
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	select {
+	case <-received:
+		t.Fatal("push should not be sent to a recipient who is actively viewing the room")
+	case <-time.After(300 * time.Millisecond):
+		// Correct: bob is active, no push sent.
+	}
+}
+
+func TestHandlePost_PushDeliveredToInactiveRecipient(t *testing.T) {
+	received := make(chan struct{}, 10)
+	fakePush := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		received <- struct{}{}
+	}))
+	defer fakePush.Close()
+
+	sender := buildPushSender(t)
+	ts := testutil.NewTestServerWithPush(t, sender)
+	ts.SeedRoom(t, model.Room{ID: testRoom, Name: "Test Room"})
+	require.NoError(t, ts.Redis.CreateUser(context.Background(), bob))
+	require.NoError(t, ts.Redis.TouchRoomMember(context.Background(), testRoom, alice.ID))
+	require.NoError(t, ts.Redis.TouchRoomMember(context.Background(), testRoom, bob.ID))
+
+	subJSON := bobSubscriptionJSON(t, fakePush.URL)
+	require.NoError(t, ts.Redis.SavePushSubscription(context.Background(), bob.ID, fakePush.URL, subJSON))
+
+	// Bob has no viewing key → push should be delivered.
+	resp := postMsg(t, ts, alice, "hello bob")
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	select {
+	case <-received:
+		// Correct: bob has no viewing key, push delivered.
+	case <-time.After(2 * time.Second):
+		t.Fatal("push notification not delivered within 2s")
+	}
+}
+
 func TestHandlePost_MentionNotification(t *testing.T) {
 	// Use a channel to signal push delivery in a race-free way.
 	received := make(chan struct{}, 10)

--- a/internal/handler/notifications.go
+++ b/internal/handler/notifications.go
@@ -153,6 +153,25 @@ func (h *NotificationsHandler) HandleGetMute(w http.ResponseWriter, r *http.Requ
 	json.NewEncoder(w).Encode(resp) //nolint:errcheck
 }
 
+// HandleRoomActive records that the authenticated user is currently viewing the room.
+// POST /rooms/{id}/active
+func (h *NotificationsHandler) HandleRoomActive(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	roomID := r.PathValue("id")
+	_ = h.Redis.SetRoomLastActive(r.Context(), user.ID, roomID)
+	_ = h.Redis.SetRoomViewing(r.Context(), user.ID, roomID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleRoomInactive clears the viewing key so push suppression lifts immediately.
+// POST /rooms/{id}/inactive  (called via navigator.sendBeacon on visibilitychange → hidden)
+func (h *NotificationsHandler) HandleRoomInactive(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	roomID := r.PathValue("id")
+	_ = h.Redis.ClearRoomViewing(r.Context(), user.ID, roomID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // HandleRoomMembers returns the list of room members for @mention autocomplete.
 // GET /rooms/{id}/members  → [{ id, name, avatar_url }, ...]
 func (h *NotificationsHandler) HandleRoomMembers(w http.ResponseWriter, r *http.Request) {

--- a/internal/handler/notifications_test.go
+++ b/internal/handler/notifications_test.go
@@ -201,6 +201,43 @@ func TestHandleGetMute_Forever(t *testing.T) {
 	assert.Equal(t, "forever", body["until"])
 }
 
+func TestHandleRoomActive(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	ts.SeedRoom(t, model.Room{ID: testRoom, Name: "Test Room"})
+	cookie := ts.AuthCookie(t, alice)
+
+	req, _ := http.NewRequest("POST", ts.Server.URL+"/rooms/"+testRoom+"/active", nil)
+	req.AddCookie(cookie)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	viewing, err := ts.Redis.IsRoomViewing(context.Background(), alice.ID, testRoom)
+	require.NoError(t, err)
+	assert.True(t, viewing, "viewing key should be set after /active")
+}
+
+func TestHandleRoomInactive(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	ts.SeedRoom(t, model.Room{ID: testRoom, Name: "Test Room"})
+	cookie := ts.AuthCookie(t, alice)
+
+	// Seed a viewing key first.
+	require.NoError(t, ts.Redis.SetRoomViewing(context.Background(), alice.ID, testRoom))
+
+	req, _ := http.NewRequest("POST", ts.Server.URL+"/rooms/"+testRoom+"/inactive", nil)
+	req.AddCookie(cookie)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	viewing, err := ts.Redis.IsRoomViewing(context.Background(), alice.ID, testRoom)
+	require.NoError(t, err)
+	assert.False(t, viewing, "viewing key should be cleared after /inactive")
+}
+
 func TestHandleRoomMembers(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	ts.SeedRoom(t, model.Room{ID: testRoom, Name: "Test Room"})

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -625,6 +626,59 @@ func (c *Client) GetMuteUntil(ctx context.Context, userID string) (until time.Ti
 		return time.Time{}, false, nil
 	}
 	return t, true, nil
+}
+
+// ---------------------------------------------------------------------------
+// Room activity (last_active / read cursor)
+// ---------------------------------------------------------------------------
+
+// SetRoomLastActive records the current time as the user's last-active timestamp
+// for a room. TTL is 30 days (matching message TTL) so the value survives after
+// the session ends and can be used for future unread-count work.
+func (c *Client) SetRoomLastActive(ctx context.Context, userID, roomID string) error {
+	key := "users:" + userID + ":rooms:" + roomID + ":last_active"
+	val := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	return c.rdb.Set(ctx, key, val, messageTTL).Err()
+}
+
+// GetRoomLastActive retrieves the last-active timestamp for a user in a room.
+// Returns (zero, false, nil) when no record exists.
+func (c *Client) GetRoomLastActive(ctx context.Context, userID, roomID string) (time.Time, bool, error) {
+	key := "users:" + userID + ":rooms:" + roomID + ":last_active"
+	val, err := c.rdb.Get(ctx, key).Result()
+	if errors.Is(err, goredis.Nil) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	ms, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return time.UnixMilli(ms), true, nil
+}
+
+// SetRoomViewing records that the user is actively viewing the room.
+// The key expires after roomViewingTTL; the heartbeat must refresh it to keep
+// it alive. When the user leaves (visibilitychange → hidden) the client sends
+// a beacon to clear the key immediately.
+const roomViewingTTL = 90 * time.Second
+
+func (c *Client) SetRoomViewing(ctx context.Context, userID, roomID string) error {
+	key := "users:" + userID + ":rooms:" + roomID + ":viewing"
+	return c.rdb.Set(ctx, key, "1", roomViewingTTL).Err()
+}
+
+func (c *Client) ClearRoomViewing(ctx context.Context, userID, roomID string) error {
+	key := "users:" + userID + ":rooms:" + roomID + ":viewing"
+	return c.rdb.Del(ctx, key).Err()
+}
+
+func (c *Client) IsRoomViewing(ctx context.Context, userID, roomID string) (bool, error) {
+	key := "users:" + userID + ":rooms:" + roomID + ":viewing"
+	exists, err := c.rdb.Exists(ctx, key).Result()
+	return exists > 0, err
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -158,6 +158,8 @@ func buildMux(rc *redisclient.Client, renderer *tmpl.Renderer, webFS fs.FS, secr
 	mux.Handle("PATCH /rooms/{id}/messages/{msgID}", authMW(http.HandlerFunc(messagesHandler.HandleEdit)))
 	mux.Handle("POST /rooms/{id}/messages/{msgID}/reactions", authMW(http.HandlerFunc(reactionsHandler.HandleToggle)))
 	mux.Handle("GET /rooms/{id}/members", authMW(http.HandlerFunc(notificationsHandler.HandleRoomMembers)))
+	mux.Handle("POST /rooms/{id}/active", authMW(http.HandlerFunc(notificationsHandler.HandleRoomActive)))
+	mux.Handle("POST /rooms/{id}/inactive", authMW(http.HandlerFunc(notificationsHandler.HandleRoomInactive)))
 
 	// Push notification routes.
 	mux.HandleFunc("GET /push/vapid-public-key", notificationsHandler.HandleVAPIDPublicKey)

--- a/main.go
+++ b/main.go
@@ -217,6 +217,8 @@ func main() {
 	mux.Handle("PATCH /rooms/{id}/messages/{msgID}", authMW(http.HandlerFunc(messagesHandler.HandleEdit)))
 	mux.Handle("POST /rooms/{id}/messages/{msgID}/reactions", authMW(http.HandlerFunc(reactionsHandler.HandleToggle)))
 	mux.Handle("GET /rooms/{id}/members", authMW(http.HandlerFunc(notificationsHandler.HandleRoomMembers)))
+	mux.Handle("POST /rooms/{id}/active", authMW(http.HandlerFunc(notificationsHandler.HandleRoomActive)))
+	mux.Handle("POST /rooms/{id}/inactive", authMW(http.HandlerFunc(notificationsHandler.HandleRoomInactive)))
 
 	// Push notification routes.
 	mux.HandleFunc("GET /push/vapid-public-key", notificationsHandler.HandleVAPIDPublicKey)

--- a/web/templates/room.html
+++ b/web/templates/room.html
@@ -197,4 +197,42 @@
 
 </script>
 <script src="/static/room.js?v={{$.BuildVersion}}"></script>
+<script>
+(function () {
+  var activeURL = '/rooms/{{.Data.Room.ID}}/active';
+  var inactiveURL = '/rooms/{{.Data.Room.ID}}/inactive';
+  var heartbeatTimer = null;
+
+  function ping() {
+    fetch(activeURL, { method: 'POST' }).catch(function () {});
+  }
+
+  function leave() {
+    navigator.sendBeacon(inactiveURL);
+  }
+
+  function startHeartbeat() {
+    ping();
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = setInterval(ping, 60 * 1000);
+  }
+
+  function stopHeartbeat() {
+    clearInterval(heartbeatTimer);
+    leave();
+  }
+
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'visible') {
+      startHeartbeat();
+    } else {
+      stopHeartbeat();
+    }
+  });
+
+  if (document.visibilityState === 'visible') {
+    startHeartbeat();
+  }
+})();
+</script>
 {{end}}


### PR DESCRIPTION
Track last_active per user per room (Redis String, unix ms, 30-day TTL). Skip Web Push if the recipient's last_active is within the last 2 minutes. Client pings POST /rooms/{id}/active on page load, visibilitychange, and every 60 s while visible. Message send also updates last_active for the sender. Same key serves as read cursor for future unread-count work.