### PR TITLE
Style emoji picker to match app theme

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -932,7 +932,20 @@ img { display: block; max-width: 100%; }
   z-index: 999;
   box-shadow: var(--shadow-md);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+}
+
+emoji-picker {
+  --background:                var(--color-bg);
+  --border-color:              var(--color-border);
+  --border-radius:             var(--radius-lg);
+  --button-hover-background:   var(--color-bg-subtle);
+  --button-active-background:  var(--color-bg-sidebar);
+  --indicator-color:           var(--color-primary);
+  --input-border-color:        var(--color-border);
+  --input-font-color:          var(--color-text);
+  --input-placeholder-color:   var(--color-text-muted);
+  --outline-color:             var(--color-primary);
+  --category-font-color:       var(--color-text-muted);
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary
- Maps `emoji-picker-element` CSS variables to our design tokens so the picker uses the same colours in both light and dark mode (background, border, inputs, hover/active states, primary indicator)
- Removes `overflow: hidden` from the container; sets `--border-radius` on the element itself so it handles its own corner rounding without clipping the border

## Test plan
- [ ] Open emoji picker in light mode — colours match the app
- [ ] Switch to dark mode — colours follow correctly
- [ ] Rounded corners visible without border clipping